### PR TITLE
Fix Missing `secret_key_base` Issue

### DIFF
--- a/warvox/setup.sh
+++ b/warvox/setup.sh
@@ -30,5 +30,6 @@ sh -c "echo 'production:
 
 cd /home/warvox 
 make database
+cp /home/warvox/config/secrets.yml.example /home/warvox/config/secrets.yml
 bin/adduser admin godsexlove
 bin/warvox.rb --address 0.0.0.0


### PR DESCRIPTION
Fixes this error ERROR RuntimeError: Missing `secret_key_base` for 'production' environment, set this value in `config/secrets.yml`